### PR TITLE
Fix random distribution

### DIFF
--- a/index.js
+++ b/index.js
@@ -2904,7 +2904,7 @@ const words = [
   'zone',
 ];
 
-const random = (min, max) => Math.round(min + Math.random() * (max - min));
+const random = (min, max) => Math.floor(min + Math.random() * (max - min + 1));
 
 export default words;
 


### PR DESCRIPTION
Using Math.round resulted in result being non-uniform with the first & last elements of array being 2 times less likely to be the result

# Testing
This could be tested with something like the following script

<details><summary>Distribution test example script</summary>
<p>

```js
const random = (min, max) => Math.floor(min + Math.random() * (max - min + 1));

const result = {};
const iterations = 10000000;

for (let i = 0; i < iterations; i++) {
  const x = random(0, 9);
  if (x in result) {
    result[x]++;
  } else {
    result[x] = 1;
  }
}

console.log(result);

Object.keys(result).forEach((key) => {
  result[key] /= iterations;
});

console.log(result);
```

</p>
</details> 

With the following output:

## using .floor
```js
// hits
{
  '0': 999549,
  '1': 1001674,
  '2': 1002112,
  '3': 1000049,
  '4': 998616,
  '5': 999620,
  '6': 1000871,
  '7': 1000494,
  '8': 1000445,
  '9': 996570
}
// percentages
{
  '0': 0.0999549,
  '1': 0.1001674,
  '2': 0.1002112,
  '3': 0.1000049,
  '4': 0.0998616,
  '5': 0.099962,
  '6': 0.1000871,
  '7': 0.1000494,
  '8': 0.1000445,
  '9': 0.099657
}
```

## using .round
```js
// hits
{
  '0': 556712,
  '1': 1110911,
  '2': 1111305,
  '3': 1110546,
  '4': 1110302,
  '5': 1110088,
  '6': 1110939,
  '7': 1111034,
  '8': 1111313,
  '9': 556850
}
// percentages
{
  '0': 0.0556712,
  '1': 0.1110911,
  '2': 0.1111305,
  '3': 0.1110546,
  '4': 0.1110302,
  '5': 0.1110088,
  '6': 0.1110939,
  '7': 0.1111034,
  '8': 0.1111313,
  '9': 0.055685
}
```
