### PR TITLE
Add "exports" field to fix DEP0151 DeprecationWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/nkzw-tech/safe-word-list.git"
   },
   "type": "module",
+  "exports": "./index.js",
   "license": "MIT",
   "keywords": [
     "word",


### PR DESCRIPTION
## Summary
- Add `"exports": "./index.js"` to `package.json` to fix the `[DEP0151] DeprecationWarning` caused by Node.js resolving the main entry point implicitly when no `"main"` or `"exports"` field is defined.

## Test plan
- Install the package and verify the deprecation warning no longer appears when importing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)